### PR TITLE
Use explicit assignment syntax for properties

### DIFF
--- a/buildSrc/src/main/groovy/acrolinx-sidebar-demo.java-application-conventions.gradle
+++ b/buildSrc/src/main/groovy/acrolinx-sidebar-demo.java-application-conventions.gradle
@@ -74,6 +74,6 @@ tasks.named('test', Test) {
     useJUnitPlatform()
 
     testLogging {
-        exceptionFormat 'full'
+        exceptionFormat = 'full'
     }
 }


### PR DESCRIPTION
See https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#groovy_space_assignment_syntax